### PR TITLE
Aa dev

### DIFF
--- a/examples/example_exp.py
+++ b/examples/example_exp.py
@@ -1,0 +1,18 @@
+from curry_fabric.curriedfunc import curry, p
+
+import numpy as np
+from sklearn.decomposition import PCA
+
+STEPS = 3
+
+lk = p(STEPS, (10, 30))
+kit = p(STEPS, (1000, 5000))
+pp = p(STEPS, (1, 5))
+pd = p(STEPS, (0.1, 0.7))
+ld = p(STEPS, (100, 300))
+
+
+@curry
+def test(lk, kit, pp, pd, ld):
+    return lk * ((kit * pp * pd) / ld)
+

--- a/examples/example_exp.py
+++ b/examples/example_exp.py
@@ -3,6 +3,8 @@ from curry_fabric.curriedfunc import curry, p
 import numpy as np
 from sklearn.decomposition import PCA
 
+np.set_printoptions(precision=3, suppress=True)
+
 STEPS = 3
 
 lk = p(STEPS, (10, 30))
@@ -16,3 +18,8 @@ ld = p(STEPS, (100, 300))
 def test(lk, kit, pp, pd, ld):
     return lk * ((kit * pp * pd) / ld)
 
+
+def test_(lk, kit, pp, pd, ld):
+    return lk * ((kit * pp * pd) / ld)
+
+print(test_( 30. ,   5000. ,     5. ,      0.7 ,   300. ))

--- a/src/curry_fabric/curriedfunc.py
+++ b/src/curry_fabric/curriedfunc.py
@@ -1,10 +1,8 @@
 from itertools import product, repeat
-import numpy as np
-from itertools import product, repeat
 
 import numpy as np
 
-np.set_printoptions(suppress=True)
+np.set_printoptions(precision=3, suppress=True)
 STEPS = 3
 
 
@@ -31,10 +29,9 @@ def curry(func):
                 answs = []
                 for i in list_test:
                     p = func(*(i))
-                    # возвращвем один массив вместо двух, эта реализация может упростить дальнейшую работу с шейпом, но это не точно
+
                     answs.append([*i, p])
 
-                # соответственно один решейп
                 # reshp_list=list_test.reshape((*repeat(list(steps_)[0], func.__code__.co_argcount),func.__code__.co_argcount))
                 reshp_answs = np.asarray(answs).reshape(
                     (*repeat(list(steps_)[0], func.__code__.co_argcount), func.__code__.co_argcount + 1))
@@ -58,7 +55,6 @@ def test(lk, kit, pp, pd, ld):
     return lk * ((kit * pp * pd) / ld)
 
 
-# один аутпут
 ans = test(lk, kit, pp, pd, ld)
 
 # al = list_t.T[:,:,:,1,1,1]

--- a/src/curry_fabric/curriedfunc.py
+++ b/src/curry_fabric/curriedfunc.py
@@ -1,5 +1,7 @@
-from itertools import product, repeat
+from itertools import product
+
 import numpy as np
+
 
 class p:
     def __init__(self, n, intrv):
@@ -8,29 +10,28 @@ class p:
         self.intrv = intrv
         self.vals = np.linspace(self.start, self.stop, n)
 
-def curry(func):
+
+def curry(func: callable) -> callable:
+    """
+    :rtype: callable
+    """
+
     def curried(*args):
 
         if len(args) == func.__code__.co_argcount:
-            steps_ = set()
-            to_pr = []
-            for arg in args:
-                v = arg.vals
-                to_pr.append(v)
-                steps_.add(len(v))
+            steps_: set[int] = set()
+
+            steps_.update([len(arg.vals) for arg in args])  # сет получаем через update чтобы облегчить синтаксис
+
+            to_pr = [arg.vals for arg in args]  # упрощаем цикл
             if len(steps_) == 1:
+                # векторизируем функцию под numpy аргументы, чтобы избежать длинного цикла подстановки
+                vfunc = np.vectorize(func)
+
                 list_test = np.asarray(list(product(*to_pr)))
-                answers = []
-                for i in list_test:
-                    ans = func(*(i))
+                answers = vfunc(*list_test.T)
 
-                    answers.append([*i, ans])
-
-                # reshp_list=list_test.reshape((*repeat(list(steps_)[0], func.__code__.co_argcount),
-                # func.__code__.co_argcount))
-                reshape_answer = np.asarray(answers).reshape(
-                    (*repeat(list(steps_)[0], func.__code__.co_argcount), func.__code__.co_argcount + 1))
-                return reshape_answer
+                return np.c_[list_test, answers]
             else:
                 print(f'steps count not identical: {steps_}')
         else:

--- a/src/curry_fabric/curriedfunc.py
+++ b/src/curry_fabric/curriedfunc.py
@@ -1,10 +1,5 @@
 from itertools import product, repeat
-
 import numpy as np
-
-np.set_printoptions(precision=3, suppress=True)
-STEPS = 3
-
 
 class p:
     def __init__(self, n, intrv):
@@ -13,49 +8,32 @@ class p:
         self.intrv = intrv
         self.vals = np.linspace(self.start, self.stop, n)
 
-
-
 def curry(func):
     def curried(*args):
+
         if len(args) == func.__code__.co_argcount:
-            steps_=set()
-            to_pr=[]
+            steps_ = set()
+            to_pr = []
             for arg in args:
                 v = arg.vals
                 to_pr.append(v)
                 steps_.add(len(v))
-            if len(steps_)==1:
+            if len(steps_) == 1:
                 list_test = np.asarray(list(product(*to_pr)))
-                answs = []
+                answers = []
                 for i in list_test:
-                    p = func(*(i))
+                    ans = func(*(i))
 
-                    answs.append([*i, p])
+                    answers.append([*i, ans])
 
-                # reshp_list=list_test.reshape((*repeat(list(steps_)[0], func.__code__.co_argcount),func.__code__.co_argcount))
-                reshp_answs = np.asarray(answs).reshape(
+                # reshp_list=list_test.reshape((*repeat(list(steps_)[0], func.__code__.co_argcount),
+                # func.__code__.co_argcount))
+                reshape_answer = np.asarray(answers).reshape(
                     (*repeat(list(steps_)[0], func.__code__.co_argcount), func.__code__.co_argcount + 1))
-                return reshp_answs
+                return reshape_answer
             else:
-                print(f'steps count not identic: {steps_}')
+                print(f'steps count not identical: {steps_}')
         else:
-            return (lambda *x: curried(*(args + x)))              
+            return lambda *x: curried(*(args + x))
+
     return curried
-
-
-lk = p(STEPS, (10, 30))
-kit = p(STEPS, (1000, 5000))
-pp = p(STEPS, (1, 5))
-pd = p(STEPS, (0.1, 0.7))
-ld = p(STEPS, (100, 300))
-
-
-@curry
-def test(lk, kit, pp, pd, ld):
-    return lk * ((kit * pp * pd) / ld)
-
-
-ans = test(lk, kit, pp, pd, ld)
-
-# al = list_t.T[:,:,:,1,1,1]
-print(ans, ans.T)

--- a/src/curry_fabric/curriedfunc.py
+++ b/src/curry_fabric/curriedfunc.py
@@ -1,13 +1,15 @@
-import math
-import operator
-import functools
 from itertools import product, repeat
-from textwrap import wrap
 import numpy as np
+from itertools import product, repeat
+
+import numpy as np
+
 np.set_printoptions(suppress=True)
-STEPS = 2
+STEPS = 3
+
+
 class p:
-    def __init__ (self, n, intrv):
+    def __init__(self, n, intrv):
         self.n = n
         self.start, self.stop = intrv
         self.intrv = intrv
@@ -26,13 +28,17 @@ def curry(func):
                 steps_.add(len(v))
             if len(steps_)==1:
                 list_test = np.asarray(list(product(*to_pr)))
-                answs=[]
+                answs = []
                 for i in list_test:
                     p = func(*(i))
-                    answs.append(p)
-                reshp_list=list_test.reshape((*repeat(list(steps_)[0], func.__code__.co_argcount),func.__code__.co_argcount))
-                reshp_answs=np.asarray(answs).reshape((*repeat(list(steps_)[0],func.__code__.co_argcount),1))
-                return reshp_list, reshp_answs
+                    # возвращвем один массив вместо двух, эта реализация может упростить дальнейшую работу с шейпом, но это не точно
+                    answs.append([*i, p])
+
+                # соответственно один решейп
+                # reshp_list=list_test.reshape((*repeat(list(steps_)[0], func.__code__.co_argcount),func.__code__.co_argcount))
+                reshp_answs = np.asarray(answs).reshape(
+                    (*repeat(list(steps_)[0], func.__code__.co_argcount), func.__code__.co_argcount + 1))
+                return reshp_answs
             else:
                 print(f'steps count not identic: {steps_}')
         else:
@@ -40,22 +46,20 @@ def curry(func):
     return curried
 
 
-
-lk = p(STEPS,(10,30))
-kit = p(STEPS,(1000,5000))
-pp = p(STEPS,(1,5))
-pd = p(STEPS,(0.1,0.7))
-ld = p(STEPS,(100,300))
+lk = p(STEPS, (10, 30))
+kit = p(STEPS, (1000, 5000))
+pp = p(STEPS, (1, 5))
+pd = p(STEPS, (0.1, 0.7))
+ld = p(STEPS, (100, 300))
 
 
 @curry
 def test(lk, kit, pp, pd, ld):
-    return lk*((kit*pp*pd)/ld) 
-
-list_t, ans = test(lk, kit, pp, pd, ld)
+    return lk * ((kit * pp * pd) / ld)
 
 
-print (list_t[0,0,0,0,0,:], ans[0,0,0,0,0,0])
+# один аутпут
+ans = test(lk, kit, pp, pd, ld)
 
-
-
+# al = list_t.T[:,:,:,1,1,1]
+print(ans, ans.T)


### PR DESCRIPTION

## summary

#  https://github.com/sf-d/curry_fabric/commit/c88125932984ba6edc09fdce2c1bc6ab3856f4ad
Сократил количество строк в декорaторе **_curry_**

Reduced the number of lines in the decorator **_curry_**

> упрощена генерация сета
> упрощена генерация входящего массива
> упрощен метод передачи массива в функцию. Теперь это происходит через [numpy.vectorize](https://numpy.org/doc/stable/reference/generated/numpy.vectorize.html)

> simplified set generation
> incoming array generation has been simplified
> simplified the method of passing an array to a function. This is now done via [numpy.vectorize](https://numpy.org/doc/stable/reference/generated/numpy.vectorize.html)


# https://github.com/sf-d/curry_fabric/commit/c88125932984ba6edc09fdce2c1bc6ab3856f4ad#r68034534
Есть предложение возвращать один массив вместо двух, тк потом все равно необходимо их сливать
> реализация через [numpy.c_[ ]](https://numpy.org/doc/stable/reference/generated/numpy.c_.html?highlight=c_#numpy.c_)
`return np.c_[list_test, answers]`

There is a suggestion to return one array instead of two, because you have to merge them later anyway
> implementation via [numpy.c_[ ]](https://numpy.org/doc/stable/reference/generated/numpy.c_.html?highlight=c_#numpy.c_)
`return np.c_[list_test, answers]`